### PR TITLE
fix mouse reconnecting

### DIFF
--- a/BleConnectionStatus.cpp
+++ b/BleConnectionStatus.cpp
@@ -8,6 +8,8 @@ void BleConnectionStatus::onConnect(BLEServer* pServer)
   this->connected = true;
   BLE2902* desc = (BLE2902*)this->inputKeyboard->getDescriptorByUUID(BLEUUID((uint16_t)0x2902));
   desc->setNotifications(true);
+  desc = (BLE2902*)this->inputMouse->getDescriptorByUUID(BLEUUID((uint16_t)0x2902));
+  desc->setNotifications(true);
 }
 
 void BleConnectionStatus::onDisconnect(BLEServer* pServer)
@@ -15,4 +17,6 @@ void BleConnectionStatus::onDisconnect(BLEServer* pServer)
   this->connected = false;
   BLE2902* desc = (BLE2902*)this->inputKeyboard->getDescriptorByUUID(BLEUUID((uint16_t)0x2902));
   desc->setNotifications(false);
+  desc = (BLE2902*)this->inputMouse->getDescriptorByUUID(BLEUUID((uint16_t)0x2902));
+  desc->setNotifications(false);  
 }


### PR DESCRIPTION
The mouse is not properly reconnected when the ESP32 reboots or gets out of range. After reenabling the notifications on the mouse descriptor this works as expected.