### PR TITLE
restart advertising after disconnect

### DIFF
--- a/BleConnectionStatus.cpp
+++ b/BleConnectionStatus.cpp
@@ -18,5 +18,7 @@ void BleConnectionStatus::onDisconnect(BLEServer* pServer)
   BLE2902* desc = (BLE2902*)this->inputKeyboard->getDescriptorByUUID(BLEUUID((uint16_t)0x2902));
   desc->setNotifications(false);
   desc = (BLE2902*)this->inputMouse->getDescriptorByUUID(BLEUUID((uint16_t)0x2902));
-  desc->setNotifications(false);  
+  desc->setNotifications(false);
+  
+  pServer->getAdvertising()->start();
 }


### PR DESCRIPTION
After disconnect, device dont appear on scan without restart advertising